### PR TITLE
Add a homepage link to the github project

### DIFF
--- a/engine-io-snap/engine-io-snap.cabal
+++ b/engine-io-snap/engine-io-snap.cabal
@@ -1,5 +1,6 @@
 name: engine-io-snap
 version: 1.0.1
+homepage: http://github.com/ocharles/engine.io
 license: BSD3
 license-file: LICENSE
 author: Oliver Charles

--- a/socket-io/socket-io.cabal
+++ b/socket-io/socket-io.cabal
@@ -1,5 +1,6 @@
 name: socket-io
 version: 1.0.1
+homepage: http://github.com/ocharles/engine.io
 license: BSD3
 license-file: LICENSE
 author: Oliver Charles


### PR DESCRIPTION
This way it's easier to find the github project when browsing
socket-io or engine-io-snap on Hackage.
