### PR TITLE
Parametrizing EventHandler using monad

### DIFF
--- a/examples/chat/Chat.hs
+++ b/examples/chat/Chat.hs
@@ -59,7 +59,7 @@ instance Aeson.ToJSON UserJoined where
 --------------------------------------------------------------------------------
 data ServerState = ServerState { ssNConnected :: STM.TVar Int }
 
---server :: ServerState -> StateT SocketIO.RoutingTable Snap.Snap ()
+--server :: (Functor m, Monad m, MonadIO m) => ServerState -> SocketIO.SocketHandler m ()
 server state = do
   userNameMVar <- liftIO STM.newEmptyTMVarIO
   let forUserName m = liftIO (STM.atomically (STM.tryReadTMVar userNameMVar)) >>= mapM_ m

--- a/examples/chat/Chat.hs
+++ b/examples/chat/Chat.hs
@@ -78,6 +78,18 @@ server state = do
     SocketIO.emit "login" (NumConnected n)
     SocketIO.broadcast "user joined" (UserJoined userName n)
 
+  SocketIO.appendDisconnectHandler $ do
+    (n, mUserName) <- liftIO $ STM.atomically $ do
+      n <- (+ (-1)) <$> STM.readTVar (ssNConnected state)
+      mUserName <- STM.tryReadTMVar userNameMVar
+      STM.writeTVar (ssNConnected state) n
+      return (n, mUserName)
+
+    case mUserName of
+     Nothing -> return ()
+     Just userName ->
+       SocketIO.broadcast "user left" (UserJoined userName n)
+
   SocketIO.on_ "typing" $
     forUserName $ \userName ->
       SocketIO.broadcast "typing" (UserName userName)

--- a/examples/chat/MainSnap.hs
+++ b/examples/chat/MainSnap.hs
@@ -17,7 +17,7 @@ import Paths_chat (getDataDir)
 main :: IO ()
 main = do
   state <- ServerState <$> STM.newTVarIO 0
-  socketIoHandler <- SocketIO.initialize EIOSnap.snapAPI (server state)
+  socketIoHandler <- SocketIO.initialize EIOSnap.snapAPI (server state :: SocketIO.SocketHandler Snap.Snap ())
   dataDir <- getDataDir
   Snap.quickHttpServe $
     Snap.route [ ("/socket.io", socketIoHandler)

--- a/examples/chat/MainYesod.hs
+++ b/examples/chat/MainYesod.hs
@@ -46,5 +46,5 @@ handleSocketIOR = YC.getYesod >>= socketIoHandler
 main :: IO ()
 main = do
   state <- ServerState <$> STM.newTVarIO 0
-  app <- YesodChat <$> SocketIO.initialize EIOYesod.yesodAPI (server state)
+  app <- YesodChat <$> SocketIO.initialize EIOYesod.yesodAPI (server state :: SocketIO.SocketHandler Handler ())
   YC.warp 8000 app

--- a/socket-io/src/Network/SocketIO.hs
+++ b/socket-io/src/Network/SocketIO.hs
@@ -1,11 +1,15 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Network.SocketIO
   ( -- $intro
     -- * Running Socket.IO Applications
-    initialize
-
+    SocketAppToIO(..)
+  , initialize
+  
     -- * Receiving events
+  , RoutingTableT
   , RoutingTable
   , on
   , on_
@@ -13,7 +17,12 @@ module Network.SocketIO
   , appendDisconnectHandler
 
   -- * Emitting Events
+  , EventHandlerT
   , EventHandler
+  
+  -- * Provide Handler
+  , SocketHandlerT
+  , SocketHandler
 
   -- ** To One Client
   , emit
@@ -135,10 +144,18 @@ encodePacket :: Packet -> Builder.Builder
 encodePacket (Packet pt attachments n pId json) =
   encodePacketType pt <> fromMaybe mempty (Builder.lazyByteString . Aeson.encode <$> json)
 
+class SocketAppToIO m m' where
+  socketAppToIO :: m (m' a -> IO a)
+
+instance (Monad m) => SocketAppToIO m IO where
+  socketAppToIO = return id
 
 --------------------------------------------------------------------------------
-type EventHandler a = ReaderT Socket IO a
+type EventHandlerT m' = ReaderT Socket m'
+type EventHandler = EventHandlerT IO
 
+type SocketHandlerT m m' = StateT (RoutingTableT m') (EventHandlerT m)
+type SocketHandler m = SocketHandlerT m IO
 
 --------------------------------------------------------------------------------
 {-|
@@ -158,9 +175,9 @@ convenience 'on' family of functions.
 
 -}
 initialize
-  :: MonadIO m
+  :: (Functor m, MonadIO m, Functor m', MonadIO m', SocketAppToIO m m')
   => EIO.ServerAPI m
-  -> StateT RoutingTable (ReaderT Socket m) a
+  -> SocketHandlerT m m' a
   -> IO (m ())
 initialize api socketHandler = do
   eio <- EIO.initialize
@@ -170,11 +187,13 @@ initialize api socketHandler = do
       let wrappedSocket = Socket socket eio
       routingTable <- flip runReaderT wrappedSocket $
         execStateT socketHandler (RoutingTable mempty (const (return ())))
-
+      
+      runAppInIO <- socketAppToIO
+      
       return $ EIO.SocketApp
-        { EIO.saApp = flip runReaderT wrappedSocket $ do
+        { EIO.saApp = runAppInIO $ flip runReaderT wrappedSocket $ do
             emitPacketTo wrappedSocket (Packet Connect Nothing "/" Nothing Nothing)
-
+            
             forever $ do
               EIO.TextPacket t <- liftIO (STM.atomically (EIO.receive socket))
               case Attoparsec.parseOnly parsePacket (Text.encodeUtf8 t) of
@@ -191,7 +210,7 @@ initialize api socketHandler = do
 
                 Left e -> error $ "Attoparsec failed: " ++ show e
 
-        , EIO.saOnDisconnect = rtDisconnect routingTable (socketId wrappedSocket)
+        , EIO.saOnDisconnect = runAppInIO $ rtDisconnect routingTable (socketId wrappedSocket)
         }
 
   return (EIO.handler eio eioHandler api)
@@ -223,19 +242,20 @@ engineIOSocket = socketEIOSocket
 --------------------------------------------------------------------------------
 -- | A per-connection routing table. This table determines what actions to
 -- invoke when events are received.
-data RoutingTable = RoutingTable
-  { rtEvents :: HashMap.HashMap Text.Text (Aeson.Array -> MaybeT (ReaderT Socket IO) ())
-  , rtDisconnect :: EIO.SocketId -> IO ()
+data RoutingTableT m = RoutingTable
+  { rtEvents :: HashMap.HashMap Text.Text (Aeson.Array -> MaybeT (EventHandlerT m) ())
+  , rtDisconnect :: EIO.SocketId -> m ()
   }
 
+type RoutingTable = RoutingTableT IO
 
 --------------------------------------------------------------------------------
 -- | When an event with a given name is received, call the associated function
 -- with the array of JSON arguments.
 onJSON
-  :: (MonadState RoutingTable m, Applicative m)
+  :: (MonadState (RoutingTableT m') m, Applicative m, Functor m', Monad m')
   => Text.Text
-  -> (Aeson.Array -> EventHandler a)
+  -> (Aeson.Array -> EventHandlerT m' a)
   -> m ()
 onJSON eventName handler =
   modify $ \rt -> rt
@@ -252,9 +272,9 @@ onJSON eventName handler =
 -- decoded by a 'Aeson.FromJSON' instance, run the associated function
 -- after decoding the event argument. Expects exactly one event argument.
 on
-  :: (MonadState RoutingTable m, Aeson.FromJSON arg, Applicative m)
+  :: (MonadState (RoutingTableT m') m, Aeson.FromJSON arg, Applicative m, Functor m', Monad m')
   => Text.Text
-  -> (arg -> EventHandler a)
+  -> (arg -> EventHandlerT m' a)
   -> m ()
 on eventName handler =
   let eventHandler v = do
@@ -276,9 +296,9 @@ on eventName handler =
 -- | When an event is received with a given name and no arguments, run the
 -- associated 'EventHandler'.
 on_
-  :: (MonadState RoutingTable m, Applicative m)
+  :: (MonadState (RoutingTableT m') m, Applicative m, Functor m', Monad m')
   => Text.Text
-  -> EventHandler a
+  -> EventHandlerT m' a
   -> m ()
 on_ eventName handler =
   let eventHandler v = guard (V.null v) >> lift handler
@@ -296,7 +316,8 @@ on_ eventName handler =
 -- | Run the given IO action when a client disconnects, along with any other
 -- previously register disconnect handlers.
 appendDisconnectHandler
-  :: MonadState RoutingTable m => (EIO.SocketId -> IO ()) -> m ()
+  :: (MonadState (RoutingTableT m') m, Monad m')
+  => (EIO.SocketId -> m' ()) -> m ()
 appendDisconnectHandler handler = modify $ \rt -> rt
   { rtDisconnect = \sId -> do rtDisconnect rt sId
                               handler sId


### PR DESCRIPTION
Allows to use custom monad in `EventHandler` instead of `IO`.
Implementation utilizes `socketAppToIO` method for converting custom monad to `IO`.

```
class SocketAppToIO m m' where
  socketAppToIO :: m (m' a -> IO a)

instance (Monad m) => SocketAppToIO m IO where
  socketAppToIO = return id
```

As you can see, backward compatibility are also present.

So, to use Yesod Handler monad in `EventHandler` we can do it:

```
{-# LANGUAGE FlexibleInstances, MultiParamTypeClasses #-}
instance MonadIO m => SocketAppToIO (HandlerT master m) (HandlerT master IO) where
  socketAppToIO = handlerToIO
```
