### PR TITLE
engine-io: Support decoding payloads comming through XHR polling transport

### DIFF
--- a/engine-io/Changelog.md
+++ b/engine-io/Changelog.md
@@ -1,3 +1,8 @@
+## HEAD
+
+* Support decoding payloads coming through XHR polling transport.
+  Previously, this scenario would lead to HTTP 400 responses.
+
 ## 1.2.6
 
 * Increased upper-bounds of aeson to < 0.10 and of attoparsec to < 0.14.


### PR DESCRIPTION
Previously, this scenario would lead to HTTP 400 responses.

The format of this payload is described in: https://github.com/Automattic/engine.io-protocol

I tested this locally and it worked fine, both on the repl and on the browser. 