### PR TITLE
Lower lower bound for attoparsec.

### DIFF
--- a/engine-io-wai/engine-io-wai.cabal
+++ b/engine-io-wai/engine-io-wai.cabal
@@ -31,7 +31,7 @@ library
         either >= 4,
         transformers >= 0.2 && < 0.5,
         transformers-compat >= 0.4,
-        attoparsec >= 0.13 && < 0.14
+        attoparsec >= 0.10 && < 0.14
 
     hs-source-dirs: src
     default-language: Haskell2010


### PR DESCRIPTION
        'parseOnly' has been available since version 0.9, but it was originally
        exported from the now-deprecated Data.Attoparsec module. A lower bound
        of 0.10 avoids CPP or warnings.