### PR TITLE
Minor refactoring, expose WaiMonad fields

### DIFF
--- a/engine-io-wai/src/Network/EngineIO/Wai.hs
+++ b/engine-io-wai/src/Network/EngineIO/Wai.hs
@@ -4,7 +4,7 @@
 
 
 module Network.EngineIO.Wai (
-    WaiMonad,
+    WaiMonad (..),
     toWaiApplication,
     waiAPI
     ) where
@@ -18,8 +18,6 @@ import Control.Monad.Trans.Either
 import Control.Arrow (second)
 import Data.Maybe (maybeToList)
 import Data.ByteString.Lazy (toStrict)
-import Data.Text.Lazy.Encoding (encodeUtf8)
-import Data.Text.Lazy (fromStrict)
 import Data.Attoparsec.ByteString (parseOnly)
 import Network.HTTP.Types.Header (hContentType)
 
@@ -42,9 +40,9 @@ newtype WaiMonad a = WaiMonad {
 toWaiApplication :: WaiMonad a -> Application
 toWaiApplication sHandler req respond = do
     socket <- runReaderT (runEitherT (runWaiMonad sHandler)) req
-    case socket of
-        Left response -> respond response
-        Right _ -> respond $ responseLBS status200 [("Content-Type", "text/html")] $ encodeUtf8 $ fromStrict ""
+    respond $ case socket of
+        Left response -> response
+        Right _ -> responseLBS status200 [("Content-Type", "text/html")] ""
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Problem: I want my socket-io handlers to run in a monad that has some extra capabilities over `WaiMonad`, so I implement a newtype using a monad transformer, with `WaiMonad` as the base monad. The problem is, without `WaiMonad` constructors I can't implement

```haskell
waiAPI' :: ServerAPI SockIOM
```

With fields exposed, I can do it like:

```haskell
waiAPI' :: EIO.ServerAPI SockIOM
waiAPI' = EIO.ServerAPI
    { EIO.srvTerminateWithResponse =
        \code ct builder -> SockIOM (lift (EIO.srvTerminateWithResponse waiAPI code ct builder))

    , EIO.srvGetQueryParams =
        SockIOM (lift (EIO.srvGetQueryParams waiAPI))

    , EIO.srvParseRequestBody =
        \p -> SockIOM (lift (EIO.srvParseRequestBody waiAPI p))

    , EIO.srvGetRequestMethod =
        SockIOM (lift (fmap WAI.requestMethod ask))

    , EIO.srvRunWebSocket =
        \app -> SockIOM (lift (EIO.srvRunWebSocket waiAPI app))
    }
```

(`SockIOM` is the monad that adds some extra functionality over `WaiMonad`)

Now I can initialize (with `Network.EngineIO.initialize`) my endpoint so that my handlers run in `SockIOM` rather than `WaiMonad`, without having to re-implement all the `WaiMonad` functionality.