### PR TITLE
Tighten lower bound for engine-io:base

### DIFF
--- a/engine-io/engine-io.cabal
+++ b/engine-io/engine-io.cabal
@@ -30,7 +30,7 @@ library
     aeson >=0.7 && <1.5,
     async >=2.0 && <2.3,
     attoparsec >=0.11 && <0.14,
-    base >=4.6 && <4.13,
+    base >=4.8 && <4.13,
     base64-bytestring >=1.0 && <1.1,
     bytestring >=0.10.2.0 && <0.11,
     errors >= 2.0.0 && <2.4,


### PR DESCRIPTION

...because:

```
Configuring library for engine-io-1.2.22..
Preprocessing library for engine-io-1.2.22..
Building library for engine-io-1.2.22..
[1 of 1] Compiling Network.EngineIO ( src/Network/EngineIO.hs, /tmp/matrix-worker/1538317491/dist-newstyle/build/x86_64-linux/ghc-7.8.4/engine-io-1.2.22/build/Network/EngineIO.o )

src/Network/EngineIO.hs:419:7:
    Could not deduce (Functor m) arising from a use of ‘for’
    from the context (MonadIO m)
      bound by the type signature for
                 handler :: MonadIO m =>
                            EngineIO -> (Socket -> m SocketApp) -> ServerAPI m -> m ()
      at src/Network/EngineIO.hs:410:12-82
    Possible fix:
      add (Functor m) to the context of
        the type signature for
          handler :: MonadIO m =>
                     EngineIO -> (Socket -> m SocketApp) -> ServerAPI m -> m ()
    In the expression: for (HashMap.lookup "sid" queryParams)
    In a stmt of a 'do' block:
      socket <- for (HashMap.lookup "sid" queryParams)
                $ \ sids
                    -> do { sid <- case sids of {
                                     [sid] -> ...
                                     _ -> ... };
                            mSocket <- liftIO
                                         (STM.atomically
                                            (HashMap.lookup sid <$> getOpenSockets eio));
                            .... }
    In the second argument of ‘($)’, namely
      ‘do { reqTransport <- maybe (throwE TransportUnknown) return
                            $ do { [t] <- HashMap.lookup "transport" queryParams;
                                   parseTransportType (Text.decodeUtf8 t) };
            socket <- for (HashMap.lookup "sid" queryParams)
                      $ \ sids -> do { ... };
            supportsBinary <- case HashMap.lookup "b64" queryParams of {
                                Just ["1"] -> return False
                                Just ["0"] -> return True
                                Nothing -> return True
                                _ -> throwE BadRequest };
            case socket of {
              Just s -> do { ... }
              Nothing
                -> lift (freshSession eio socketHandler api supportsBinary) } }’
```