### PR TITLE
Remove upper bound on base for GHC 8.6.5 compatibility

### DIFF
--- a/engine-io-wai/engine-io-wai.cabal
+++ b/engine-io-wai/engine-io-wai.cabal
@@ -1,5 +1,5 @@
 name: engine-io-wai
-version: 1.0.9
+version: 1.0.10
 synopsis: An @engine-io@ @ServerAPI@ that is compatible with @Wai@
 homepage: http://github.com/ocharles/engine.io
 license: BSD3
@@ -21,7 +21,7 @@ library
         Network.EngineIO.Wai
 
     build-depends:
-        base >=4.6 && <4.12,
+        base >=4.6,
         engine-io >= 1.2 && < 1.3,
         http-types >= 0.8 && < 0.13,
         unordered-containers >= 0.2 && < 0.3,


### PR DESCRIPTION
The latest Stack LTS for GHC 8.6.x includes base-4.12.0 which throws warnings when this package is used due to the upper bound defined.

This PR removes that upper bound so this package can be used warning free on the latest LTS's

@ocharles When you get a chance can you have a look at this and potentially push this to Hackage?