### PR TITLE
Add GHC 9.6+ and aeson 2.2 compatibility for socket-io

### DIFF
--- a/engine-io/engine-io.cabal
+++ b/engine-io/engine-io.cabal
@@ -27,23 +27,23 @@ library
    RankNTypes, OverloadedStrings, RecordWildCards
 
   build-depends:
-    aeson >=0.7 && <1.6,
+    aeson >=2.0 && <2.3,
     async >=2.0 && <2.3,
-    attoparsec >=0.11 && <0.14,
-    base >=4.8 && <4.15,
+    attoparsec >=0.11 && <0.15,
+    base >=4.8 && <4.21,
     base64-bytestring >=1.0 && <1.3,
-    bytestring >=0.10.2.0 && <0.12,
+    bytestring >=0.10.2.0 && <0.13,
     errors >= 2.0.0 && <2.4,
-    free >= 4.9 && <5.2,
+    free >= 4.9 && <5.3,
     monad-loops >=0.4 && <0.5,
     mwc-random >=0.13 && <0.16,
     stm >=2.4 && <2.6,
     stm-delay >= 0.1.1 && <0.2,
-    text >=0.11 && <1.3,
-    transformers >=0.2 && <0.6,
+    text >=0.11 && <2.2,
+    transformers >=0.2 && <0.7,
     unordered-containers >=0.2 && <0.3,
-    vector >=0.10 && <0.13,
-    websockets >=0.11 && <0.13
+    vector >=0.10 && <0.14,
+    websockets >=0.11 && <0.14
 
   hs-source-dirs: src
   default-language: Haskell2010

--- a/socket-io/socket-io.cabal
+++ b/socket-io/socket-io.cabal
@@ -24,6 +24,7 @@ library
   build-depends:
     aeson >=0.7 && <1.6,
     attoparsec >=0.10 && <0.14,
+    attoparsec-aeson,
     base >=4.6 && <4.15,
     bytestring >=0.10 && <0.12,
     engine-io >= 1 && <1.3,

--- a/socket-io/socket-io.cabal
+++ b/socket-io/socket-io.cabal
@@ -22,18 +22,18 @@ library
     FlexibleContexts, OverloadedStrings, RankNTypes
 
   build-depends:
-    aeson >=0.7 && <1.6,
-    attoparsec >=0.10 && <0.14,
+    aeson >=2.0 && <2.3,
+    attoparsec >=0.10 && <0.15,
     attoparsec-aeson,
-    base >=4.6 && <4.15,
-    bytestring >=0.10 && <0.12,
+    base >=4.6 && <4.21,
+    bytestring >=0.10 && <0.13,
     engine-io >= 1 && <1.3,
-    mtl >=2.1 && <2.3,
+    mtl >=2.1 && <2.4,
     stm >=2.4 && <2.6,
-    text >=0.11 && <1.3,
-    transformers >=0.2 && <0.6,
+    text >=0.11 && <2.2,
+    transformers >=0.2 && <0.7,
     unordered-containers >=0.2 && <0.3,
-    vector >=0.10 && <0.13
+    vector >=0.10 && <0.14
 
   hs-source-dirs: src
   default-language: Haskell2010

--- a/socket-io/src/Network/SocketIO.hs
+++ b/socket-io/src/Network/SocketIO.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -63,6 +64,7 @@ import Data.Ord (comparing)
 
 import qualified Control.Concurrent.STM as STM
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Parser as AesonParser
 import qualified Data.Attoparsec.ByteString as Attoparsec
 import qualified Data.Attoparsec.ByteString.Char8 as AttoparsecC8
 import qualified Data.ByteString.Builder as Builder
@@ -123,7 +125,7 @@ parsePacket = do
 
   pIdStr <- (Just <$> numberStr) <|> pure Nothing
 
-  Packet t attachments namespace pIdStr <$> ((Just <$> Aeson.json) <|> pure Nothing)
+  Packet t attachments namespace pIdStr <$> ((Just <$> AesonParser.json) <|> pure Nothing)
 
   where
 
@@ -254,7 +256,7 @@ onJSON eventName handler =
 class OnArgs a r | a -> r where
   parseArgs :: Aeson.Array -> a -> Maybe r
 
-instance OnArgs a a where
+instance OnArgs (EventHandler a) (EventHandler a) where
   parseArgs v m
     | V.null v = Just m
     | otherwise = Nothing


### PR DESCRIPTION
## Summary

This PR adds compatibility with GHC 9.6+ and aeson 2.2+ to the socket-io package.

### GHC 9.6+ fundep fix

GHC 9.6+ is stricter about functional dependency checking. The combination of:
- `class OnArgs a r | a -> r`
- `instance OnArgs a a` (generic base case)
- constraint `OnArgs f (EventHandler a)` in the `on` signature

...causes GHC 9.6+ to reject the code because the fundep + base instance forces `f ~ EventHandler a`, which is too restrictive.

**Fix**: Add `AllowAmbiguousTypes` and replace the generic base instance with an `EventHandler`-specific instance to avoid the fundep conflict.

### aeson 2.2 migration

aeson 2.2 moved the `json` attoparsec parser to the `attoparsec-aeson` package. This PR adds the `attoparsec-aeson` dependency and imports from `Data.Aeson.Parser` instead of `Data.Aeson`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)